### PR TITLE
intercept: Open libgstreamer-1.0.so.0 instead of .so

### DIFF
--- a/libs/gst/intercept/intercept.c
+++ b/libs/gst/intercept/intercept.c
@@ -83,7 +83,7 @@ get_libgstreamer ()
 #if __MACH__
 			"libgstreamer-1.0.dylib",
 #else
-			"libgstreamer-1.0.so",
+			"libgstreamer-1.0.so.0",
 #endif
 			RTLD_NOW);
   }


### PR DESCRIPTION
.so is just a symbolic link .so.0, that belongs to the -dev package,
with the other library headers.

Instead, open directly the dynamic library file.