### PR TITLE
gst-top: Fix segmentation fault

### DIFF
--- a/instruments/gst-top.c
+++ b/instruments/gst-top.c
@@ -24,6 +24,12 @@
 gint
 main (gint argc, gchar *argv[])
 {
+
+  if (argc < 2){
+    g_print("Usage: %s PROG [ARGS]\n", argv[0]);
+    return -1;
+  }
+
   g_set_prgname ("gst-top-1.0");
   g_set_application_name ("GStreamer Top Tool");
   


### PR DESCRIPTION
When executed with no arguments:

$ gst-top

[21204.094489] gst-top-1.0[2154]: segfault at 0 ip 00007fe4528ef20f sp
00007ffd93920200 error 4 in libglib-2.0.so.0.4400.1[7fe452865000+134000]