### PR TITLE
gst-report: Fix handling of empty/wrong trace files

### DIFF
--- a/instruments/gst-report.c
+++ b/instruments/gst-report.c
@@ -302,13 +302,14 @@ main (gint argc, gchar *argv[])
   
   if (!dot) {
     g_print ("ELEMENT");
-    gsize space = max_length - 7; // sizeof "ELEMENT"
+    gsize space = (max_length > 7) ? max_length - 7 : 0; // sizeof "ELEMENT"
+    if (max_length > 7)
     for (j = 0; j < space; j++)
       g_print (" ");
     
     if (show_types) {
       g_print (" TYPE");
-      space = max_type_name_length - 4; // sizeof "ELEMENT"
+      space = (max_type_name_length > 4) ? max_type_name_length - 4 : 0; // sizeof "ELEMENT"
       for (j = 0; j < space; j++) {
         g_print (" ");
       }


### PR DESCRIPTION
If a trace file is empty or cannot be parsed properly by
gst_graveyard_new_from_trace the number of sorted elements is zero
and so is the variable max_length.

This causes an "almost endless" loop on the printout.

Signed-off-by: Ricardo Ribalda Delgado <ricardo.ribalda@gmail.com>