### PR TITLE
gsttraceentry: Fix out of tree build error

### DIFF
--- a/libs/gst/trace/gsttraceentry.h
+++ b/libs/gst/trace/gsttraceentry.h
@@ -23,7 +23,7 @@
 #include <stdio.h>
 #include <glib.h>
 #include <gst/gst.h>
-#include "../../../config.h"
+#include <config.h>
 
 #define LGI_ELEMENT_NAME(element) ((element) != NULL) ? GST_ELEMENT_NAME (element) : "0"
 #define LGI_OBJECT_TYPE_NAME(element) ((element) != NULL) ? G_OBJECT_TYPE_NAME (element) : "0"


### PR DESCRIPTION
Fixes:

In file included from
../../git/tools/../libs/gst/trace/gstgraveyard.c:24:0:
../../git/tools/../libs/gst/trace/gsttraceentry.h:26:29: fatal error:
../../../config.h: No such file or directory
compilation terminated.

When build out of source tree

Signed-off-by: Ricardo Ribalda Delgado <ricardo.ribalda@gmail.com>