### PR TITLE
trace: Fix SIGSEGV with playbin (Fixes #23)

### DIFF
--- a/libs/gst/trace/gsttraceentry.c
+++ b/libs/gst/trace/gsttraceentry.c
@@ -128,7 +128,7 @@ gst_trace_element_discoved_entry_init_set_element (GstTraceElementDiscoveredEntr
   entry->element_id = element;
   g_strlcpy (entry->element_name, LGI_ELEMENT_NAME (element), GST_ELEMENT_NAME_LENGTH_MAX);
   g_strlcpy (entry->element_type_name, LGI_OBJECT_TYPE_NAME (element), GST_ELEMENT_TYPE_NAME_LENGTH_MAX);
-  entry->parent_element_id = GST_ELEMENT_PARENT (element);
+  entry->parent_element_id = element ? GST_ELEMENT_PARENT (element) : NULL;
 }
 
 void


### PR DESCRIPTION
If element is NULL GST_ELEMENT_PARENT() causes a SIGSEGV:

Program received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fffeec24700 (LWP 8096)]
gst_trace_element_discoved_entry_init_set_element
(entry=entry@entry=0x7fffe0023000, element=element@entry=0x0)
	    at
/usr/src/debug/gst-instruments/git-r0/git/libs/gst/trace/gsttraceentry.c:131
	    131  entry->parent_element_id = GST_ELEMENT_PARENT
(element);

Signed-off-by: Ricardo Ribalda Delgado <ricardo.ribalda@gmail.com>