### PR TITLE
intercept: Fix SIGSEGV with playbin3 (Fixes #23)

### DIFF
--- a/libs/gst/intercept/gstintercept.c
+++ b/libs/gst/intercept/gstintercept.c
@@ -198,7 +198,7 @@ lgi_pad_push (GstPad *sender_pad, GstBuffer *buffer)
   sender_pad = get_source_pad (sender_pad);
   
   GstElement *sender_element = GST_PAD_PARENT (sender_pad);
-  GstElement *receiver_element = GST_PAD_PARENT (receiver_pad);
+  GstElement *receiver_element = receiver_pad ? GST_PAD_PARENT (receiver_pad) : NULL;
   GstPipeline *pipeline = trace_heir (sender_element);
   
   guint64 start = get_cpu_time (thread);


### PR DESCRIPTION
receiver_pad canot be NULL when passed to GST_PAD_PARENT()

oot@qt5022-open:~# DISPLAY=:0 LD_PRELOAD=/usr/lib/libgstintercept.so.0
gdb -q --args gst-launch-1.0 playbin3
uri=file:///home/root/Hydrate-Kenny_Beltrey.ogg
Reading symbols from gst-launch-1.0...Reading symbols from
/usr/bin/.debug/gst-launch-1.0...done.
done.
(gdb) r
Starting program: /usr/bin/gst-launch-1.0 playbin3
uri=file:///home/root/Hydrate-Kenny_Beltrey.ogg
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/libthread_db.so.1".
Setting pipeline to PAUSED ...
[New Thread 0x7ffff4b02700 (LWP 8340)]
Pipeline is PREROLLING ...
[New Thread 0x7fffeffff700 (LWP 8341)]
[New Thread 0x7fffeec24700 (LWP 8342)]

Program received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fffeec24700 (LWP 8342)]
gst_pad_push (sender_pad=0x7fffe0009130, buffer=0x7ffff0021660) at
/usr/src/debug/gst-instruments/git-r0/git/libs/gst/intercept/gstintercept.c:201
201  GstElement *receiver_element = GST_PAD_PARENT (receiver_pad);
(gdb) quit

Signed-off-by: Ricardo Ribalda Delgado <ricardo.ribalda@gmail.com>