### PR TITLE
Fixed incorrect statement in autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -19,7 +19,7 @@ which "aclocal" 2>/dev/null || {
 }
 
 echo "Checking for libtool..."
-which "libtool" 2>/dev/null || {
+which "libtoolize" 2>/dev/null || {
   echo "Please install libtool."
   exit 1
 }


### PR DESCRIPTION
Fixed issue #39.
This commit is to fix an incorrect statement in autogen.sh

**Changes proposed in this PR:**
1. replaced libtool with libtoolize

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>